### PR TITLE
Fix pipenv pathing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,17 +2,17 @@ from setuptools import setup
 
 setup(
     name='xontrib-apipenv',
-    version='0.4.0',
-    url='https://github.com/deeuu/xonsh-apipenv',
+    version='0.5.0',
+    url='https://github.com/greg-hellings/xonsh-apipenv',
     license='MIT',
-    author='Dominic Ward',
-    author_email='dom@deeuu.me',
+    author='Greg Hellings',
+    author_email='greg.hellings@gmail.com',
     description='Auto activate a Pipenv virtual environment',
     packages=['xontrib'],
     package_dir={'xontrib': 'xontrib'},
     package_data={'xontrib': ['*.xsh']},
     platforms='any',
-    install_requires=['pipenv>=2018.11.26'],
+    install_requires=['pipenv>=2022'],
     classifiers=[
         'Environment :: Console',
         'Intended Audience :: End Users/Desktop',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='xontrib-apipenv',
-    version='0.5.0',
+    version='0.6.0',
     url='https://github.com/greg-hellings/xonsh-apipenv',
     license='MIT',
     author='Greg Hellings',

--- a/xontrib/xonsh-apipenv.xsh
+++ b/xontrib/xonsh-apipenv.xsh
@@ -1,7 +1,6 @@
 import os
 import pathlib
 from pipenv.project import Project
-from pipenv.core import do_where
 
 
 class PipenvActivator():

--- a/xontrib/xonsh-apipenv.xsh
+++ b/xontrib/xonsh-apipenv.xsh
@@ -42,7 +42,7 @@ class PipenvActivator():
 
             self.pipenv_proj_path = pathlib.Path(project.pipfile_location).parent
 
-            vox activate @(venv_name)
+            vox activate @(venv_path)
 
 
 _pa = PipenvActivator()


### PR DESCRIPTION
Rather than re-use the pipenv name, only, and have it end up wherever vox keeps its paths, use the full path to the pipenv virtualenv